### PR TITLE
fix(ChatScreen.js && LoginScreen.js): fix chat input that isn't cleared

### DIFF
--- a/client/src/components/ChatScreen.js
+++ b/client/src/components/ChatScreen.js
@@ -22,6 +22,8 @@ function ChatScreen({socket}) {
 
             // keep messages in this state to write on the page //
             setMessageList((prevMessages) => [...prevMessages, messageData]);
+
+            setCurrentMessage("");
         }
     }
 
@@ -58,7 +60,7 @@ function ChatScreen({socket}) {
             }
             </div>
             <div className='h-1/6 px-4 flex flex-row justify-stretch'>
-                <input className='w-9/12 mr-2'
+                <input className='w-9/12 mr-2' value={currentMessage}
                 onChange={e => setCurrentMessage(e.target.value)} 
                 placeholder='type message'/>
 

--- a/client/src/components/LoginScreen.js
+++ b/client/src/components/LoginScreen.js
@@ -14,7 +14,6 @@ function LoginScreen({socket}) {
         if(username !== "" && roomId !== ""){
             socket.emit("joining_room", roomId);
             setLoginDisplay(false);
-            console.log("joining event works...");
         }
         
         e.preventDefault();


### PR DESCRIPTION
use setCurrentMessage state to clean chat input that isn't cleared.